### PR TITLE
Fix the invalid definition of the overlaps function for degenerate intervals

### DIFF
--- a/src/pyintervals/interval.py
+++ b/src/pyintervals/interval.py
@@ -67,9 +67,9 @@ def overlaps(interval: Interval, other: Interval) -> bool:
 
 
 def contains(interval: Interval, other: Interval) -> bool:
-    # If at least one is degenerate, then we can check with overlaps.
-    if interval.is_degenerate() or other.is_degenerate():
+    # If the other interval is degenerate, then we can check with overlaps.
+    if other.is_degenerate():
         return overlaps(interval, other)
 
-    # We have 2 non-degenerate intervals.
+    # We have at least one non-degenerate interval.
     return interval.start <= other.start and interval.end >= other.end

--- a/tests/test_contains.py
+++ b/tests/test_contains.py
@@ -128,6 +128,42 @@ from tests.helpers import NOT_SO_IMPORTANT_LATER_DATE, THE_DATE
             ),
             False,
         ),
+        # Overlapping, the reference is degenerate, the other one non-degenerate
+        (
+            Interval(start=THE_DATE, end=THE_DATE),
+            Interval(
+                start=THE_DATE,
+                end=THE_DATE + timedelta(hours=12),
+            ),
+            False,
+        ),
+        # Overlapping, the reference is non-degenerate, the other one degenerate
+        (
+            Interval(start=THE_DATE, end=THE_DATE + timedelta(hours=12)),
+            Interval(
+                start=THE_DATE,
+                end=THE_DATE,
+            ),
+            True,
+        ),
+        # Non-overlapping, the reference is degenerate, the other one non-degenerate
+        (
+            Interval(start=THE_DATE, end=THE_DATE),
+            Interval(
+                start=NOT_SO_IMPORTANT_LATER_DATE,
+                end=NOT_SO_IMPORTANT_LATER_DATE + timedelta(hours=12),
+            ),
+            False,
+        ),
+        # Non-overlapping, the reference is degenerate, the other one non-degenerate
+        (
+            Interval(start=THE_DATE, end=THE_DATE + timedelta(hours=12)),
+            Interval(
+                start=NOT_SO_IMPORTANT_LATER_DATE,
+                end=NOT_SO_IMPORTANT_LATER_DATE,
+            ),
+            False,
+        ),
     ],
 )
 def test_contains(reference, other, answer):


### PR DESCRIPTION
## Problem
The `contains` function wrongly assumes that there is symmetry between the two intervals:
1. `contains(interval_1, interval_2)` should return whether `interval_1` contains `interval_2` (is non-symmetric)
2. However, `contains` checks if _either_ `interval_1` _or_ `interval_2` is degenerate. If that's the case, then it is assumed that the condition `overlaps(interval_1, interval_2)` (a symmetric operation) is sufficient to determine whether `interval_1` contains `interval_2`.
3. Indeed, whenever `interval_2` is degenerate and `interval_1` isn't, `interval_1` always contains `interval_2` whenever the two overlap.
4. However, whenever `interval_2` is non-degenerate and `interval_1` is, `interval_1` could never contain `interval_2`, even if they overlap.